### PR TITLE
Allow dynamic properties

### DIFF
--- a/application/libraries/datamapper.php
+++ b/application/libraries/datamapper.php
@@ -191,6 +191,7 @@ define('DMZ_VERSION', '1.8.3-dev');
  * Nestedsets Extension:
  *
  */
+#[\AllowDynamicProperties]
 class DataMapper implements IteratorAggregate {
 
 	/**


### PR DESCRIPTION
In PHP 8.2+ deprecations are emitted due to the extensive use of dynamic properties within the library.

The "best" solution is to define properties where possible and/or use magic getters and setters. From what I can see, both require quite a lot of work to achieve.

The "second best" option or last resort (and by far the easiest fix) is to simply allow dynamic properties.